### PR TITLE
[WIP]: fixup for ion allocator

### DIFF
--- a/osal/allocator/allocator_ion.c
+++ b/osal/allocator/allocator_ion.c
@@ -129,8 +129,13 @@ static int ion_map_fd(int fd, ion_user_handle_t handle, int *map_fd)
 static int ion_mmap(int fd, size_t length, int prot, int flags, off_t offset,
                     void **ptr)
 {
+    static unsigned long pagesize_mask = 0;
     if (ptr == NULL)
         return -EINVAL;
+
+    if (!pagesize_mask)
+        pagesize_mask = sysconf(_SC_PAGESIZE) - 1;
+    offset = (offset + pagesize_mask) & ~pagesize_mask;
 
     *ptr = mmap(NULL, length, prot, flags, fd, offset);
     if (*ptr == MAP_FAILED) {
@@ -380,6 +385,7 @@ static MPP_RET allocator_ion_import(void *ctx, MppBufferInfo *data)
         goto RET;
     }
 
+    data->fd = dup(fd_data.fd);
     data->hnd = (void *)fd_data.handle;
     data->ptr = NULL;
 RET:


### PR DESCRIPTION
Usually ion has an internal reference count, but I wonder
why it doesn't work at kernel 3.10.

Change-Id: Ie0f42cd3268dfd08ddcbd5148a68406ff4b66b7a
Signed-off-by: Randy Li <randy.li@rock-chips.com>